### PR TITLE
Improve performance when checking asset usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Features:
 - Find assets without references;
 - Detect assets referenced directly within HTML fields;
 - Cache pages to avoid repeated API calls when checking asset usage;
+- Cross-check asset references through Storyblok's API when not found in HTML;
 - Output a summary of file to be deleted, grouped by folder;
 - Perform a backup of assets before deletion;
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Features:
 
 - Find assets without references;
 - Detect assets referenced directly within HTML fields;
+- Cache pages to avoid repeated API calls when checking asset usage;
 - Output a summary of file to be deleted, grouped by folder;
 - Perform a backup of assets before deletion;
 

--- a/storyblok_assets_cleanup.py
+++ b/storyblok_assets_cleanup.py
@@ -399,7 +399,8 @@ def _main():
             continue
 
         clean_url = asset['filename'].split('?', 1)[0]
-        asset['is_in_use'] = clean_url in html_referenced_assets
+        asset['html_in_use'] = clean_url in html_referenced_assets
+        asset['is_in_use'] = asset['html_in_use'] or is_asset_in_use(asset)
         asset['to_be_deleted'] = False
 
         count += 1

--- a/storyblok_assets_cleanup.py
+++ b/storyblok_assets_cleanup.py
@@ -165,13 +165,7 @@ def _extract_storyblok_urls(data):
     return urls
 
 
-def get_html_referenced_assets(max_pages=None, start_page=1):
-    stories = get_all_paginated(
-        '/stories',
-        item_name='stories',
-        max_pages=max_pages,
-        start_page=start_page,
-    )
+def get_html_referenced_assets_from_stories(stories):
     referenced_urls = set()
 
     for story in stories:
@@ -337,7 +331,23 @@ def _main():
         for folder in all_folders
     }
 
-    html_referenced_assets = get_html_referenced_assets(max_pages=max_story_pages, start_page=1)
+    stories_cache_path = path.join(cache_directory, f'{space_id}_stories.json')
+
+    if path.exists(stories_cache_path) and use_cache:
+        all_stories = load_json(stories_cache_path)
+    else:
+        all_stories = get_all_paginated(
+            '/stories',
+            item_name='stories',
+            max_pages=max_story_pages,
+            start_page=1,
+        )
+        save_json(stories_cache_path, all_stories)
+
+    html_referenced_assets = {
+        url.split('?', 1)[0]
+        for url in get_html_referenced_assets_from_stories(all_stories)
+    }
 
     def get_folder_path_name(folder_id):
         if folder_id not in folder_ids_to_folder:
@@ -389,8 +399,7 @@ def _main():
             continue
 
         clean_url = asset['filename'].split('?', 1)[0]
-        asset['html_in_use'] = clean_url in html_referenced_assets
-        asset['is_in_use'] = asset['html_in_use'] or is_asset_in_use(asset)
+        asset['is_in_use'] = clean_url in html_referenced_assets
         asset['to_be_deleted'] = False
 
         count += 1


### PR DESCRIPTION
## Summary
- cache Storyblok pages locally when scanning for assets
- avoid per-asset API calls by checking usage from cached pages
- document the page caching behaviour in the README

## Testing
- `make lint` *(fails: pycodestyle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420b141b0883229dc8918b84f6495d